### PR TITLE
add function createUserStatesAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,35 @@ function main() {
 
 ### Support
 ioBroker-Forum, Thread: [Vorlage Skript: Erstellen von User-Datenpunkten](https://forum.iobroker.net/topic/26839/)
+
+### Asynchrone Variante
+
+Die Funktion `createUserStatesAsync()` verwendet die [neue Funktion `createStateAsync()`](https://forum.iobroker.net/topic/36999/neu-diverse-async-funktionen-im-javascript-adapter), um die einzelnen Datenpunkte zu erzeugen.
+
+Rückgabewert ist ein Promise, das mittels `Promise.all()` erzeugt wird, und damit aufgelöst wird sobald alle einzelnen Promises aufgelöst sind.
+
+
+#### Beispiel asynchron
+
+```
+let statesToCreateAsync = [
+    ['TestAsync.Test1', {'name':'Test 1', 'type':'int', 'read':true, 'write':true, 'role':'info', 'def':20, 'unit': '°C' }],
+    ['TestAsync.Test2', {'name':'Test 2', 'type':'string', 'read':true, 'write':true, 'role':'info', 'def':'Hello' }],
+    ['TestAsync.Test3', {'name':'Test 3', 'type':'string', 'read':true, 'write':true, 'role':'info', 'def':'Hello' }],
+];
+let statesToCreateAsyncForce = [
+        ['TestAsync.Test3', {'name':'Test 3', 'type':'string', 'read':true, 'write':true, 'role':'info', 'def':'World' }],
+];
+
+createUserStatesAsync("0_userdata.0", false, statesToCreateAsync)
+    .then(
+            () => { log("All states created successfully") },
+            () => { log("Error when creating states!") }
+         );
+
+createUserStatesAsync("0_userdata.0", true, statesToCreateAsyncForce)
+    .then(
+            () => { log("Test force states: All states created successfully") },
+            () => { log("Test force states: Error when creating states!") }
+         );
+```

--- a/createUserStatesAsync.js
+++ b/createUserStatesAsync.js
@@ -1,0 +1,47 @@
+/**
+ * Create states under 0_userdata.0 or javascript.x asynchronously
+ * Current Version:     https://github.com/Mic-M/iobroker.createUserStates
+ * Support:             https://forum.iobroker.net/topic/26839/
+ * Autor:               alexlukas (github)
+ * Version:             0.1 (25 April 2021)
+ * Example:             see https://github.com/Mic-M/iobroker.createUserStates#beispiel
+ * -----------------------------------------------
+ * @param {string} where          Where to create the state: '0_userdata.0' or 'javascript.x'.
+ * @param {boolean} force         Force state creation (overwrite), if state is existing.
+ * @param {array} statesToCreate  State(s) to create. single array or array of arrays
+ * @returns {Promise}             Promise combining all createStateAsync-promises
+ */
+async function createUserStatesAsync(where, force, statesToCreate) {
+
+    const LOG_DEBUG = false; // To debug this function, set to true
+
+    // Validate "where"
+    if (where.endsWith('.')) where = where.slice(0, -1); // Remove trailing dot
+    if ( (where.match(/^((javascript\.([1-9][0-9]|[0-9]))$|0_userdata\.0$)/) == null) ) {
+        log('This script does not support to create states under [' + where + ']', 'error');
+        return;
+    }
+
+    // Prepare "statesToCreate" since we also allow a single state to create
+    if(!Array.isArray(statesToCreate[0])) statesToCreate = [statesToCreate]; // wrap into array, if just one array and not inside an array
+
+    // Add "where" to STATES_TO_CREATE
+    for (let i = 0; i < statesToCreate.length; i++) {
+        let lpPath = statesToCreate[i][0].replace(/\.*\./g, '.'); // replace all multiple dots like '..', '...' with a single '.'
+        lpPath = lpPath.replace(/^((javascript\.([1-9][0-9]|[0-9])\.)|0_userdata\.0\.)/,'') // remove any javascript.x. / 0_userdata.0. from beginning
+        lpPath = where + '.' + lpPath; // add where to beginning of string
+        statesToCreate[i][0] = lpPath;
+    }
+
+    // call createStateAsync for every state that should be created
+    const statePromises = statesToCreate.map(s => {
+        if (LOG_DEBUG) log('[Debug] calling createStateAsync for [' + s[0] + ']');
+        return createStateAsync(s[0], _getInitValue(s), force, s[1]);
+    });
+    return Promise.all(statePromises);
+}
+
+function _getInitValue(state) {
+    // mimic same behavior as createState if no init value is provided
+    return (state[1]['def'] == undefined) ? null : state[1]['def'];
+}


### PR DESCRIPTION
Hi,

per [your suggestion](https://forum.iobroker.net/topic/26839/vorlage-skript-erstellen-von-user-datenpunkten/80?_=1619368878248&lang=de), I added an asynchronous variant of the `createUserStates`-function. I ommitted the code utilizing `setObject`, as in the new version of the javascript adapter createState can also be used to create states in `0_userdata.0`. I also created a new version of `createUserState`, omitting the if that differentiates between both, but did not include that here (I'd rather open a second request, if you want to include this).

As I'm not using javascript regularly at the moment, and I'm rather new to ioBroker, I'm happy for every feedback you have to the pull request! Also, if that is not against any best practice in the ioBroker context, I can also pull out some duplicated code from `createUserStates` and `createUserStatesAsync`.

Best regards, Alex